### PR TITLE
Add support for async reader through RevoltPhp

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "friendsofphp/php-cs-fixer": "^3.34",
         "phpstan/phpstan": "^1.10",
         "phpunit/phpunit": "^10.4",
-        "symfony/var-dumper": "^6.3"
+        "symfony/var-dumper": "^6.3",
+        "revolt/event-loop": "^1.0"
     },
     "scripts": {
         "phpstan": "./vendor/bin/phpstan --memory-limit=1G",

--- a/example/async-events.php
+++ b/example/async-events.php
@@ -1,0 +1,83 @@
+<?php
+
+use PhpTui\Term\Actions;
+use PhpTui\Term\Event\CharKeyEvent;
+use PhpTui\Term\Event\CodedKeyEvent;
+use PhpTui\Term\KeyCode;
+use PhpTui\Term\KeyModifiers;
+use PhpTui\Term\Terminal;
+use PhpTui\Term\Reader\AsyncStreamReader;
+use PhpTui\Term\EventProvider\AggregateEventProvider;
+use PhpTui\Term\EventProvider\SyncTtyEventProvider;
+use PhpTui\Term\EventProvider\SignalEventProvider;
+use PhpTui\Term\EventParser;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$asyncReader = AsyncStreamReader::tty();
+
+$terminal = Terminal::new(
+    eventProvider: new AggregateEventProvider([
+        new SyncTtyEventProvider($asyncReader, EventParser::new()),
+        SignalEventProvider::registered(),
+    ])
+);
+$terminal->enableRawMode();
+$terminal->execute(Actions::printString('Entering event loop, press ESC to exit'));
+$terminal->execute(Actions::moveCursorNextLine());
+$terminal->execute(Actions::enableMouseCapture());
+
+try {
+    $timerId = \Revolt\EventLoop::repeat(1, function () use ($terminal) {
+        static $tick = 0;
+        $terminal->queue(
+            Actions::setTitle(\sprintf('Background counter %d', ++$tick)),
+        );
+        $terminal->flush();
+    });
+
+    // enter the event loop
+    eventLoop($terminal);
+} finally {
+    // restore the terminal to it's previous state
+    $terminal->execute(Actions::disableMouseCapture());
+    $terminal->disableRawMode();
+    // cancel the timer
+    \Revolt\EventLoop::cancel($timerId);
+}
+
+function eventLoop(Terminal $terminal): void
+{
+    // start the loop!
+    while (true) {
+
+        // drain any events from the event buffer and process them
+        while ($event = $terminal->events()->next()) {
+
+            // queue multiple actions
+            $terminal->queue(
+                Actions::printString($event->__toString()),
+                Actions::moveCursorNextLine(),
+            );
+
+            // flush the buffer and write the actions to the terminal
+            $terminal->flush();
+
+            // events can be of different types containing different information
+            if ($event instanceof CodedKeyEvent) {
+                if ($event->code === KeyCode::Esc) {
+                    return;
+                }
+            }
+
+            // most events also have modifiers so you can see if the event happened
+            // with a key modifier such as CONTROL or ALT
+            if ($event instanceof CharKeyEvent) {
+                if ($event->char === 'c' && $event->modifiers === KeyModifiers::CONTROL) {
+                    return;
+                }
+            }
+        }
+        usleep(10000);
+    }
+}

--- a/src/EventProvider/SyncTtyEventProvider.php
+++ b/src/EventProvider/SyncTtyEventProvider.php
@@ -31,7 +31,7 @@ final class SyncTtyEventProvider implements EventProvider
         while ($event = array_shift($this->buffer)) {
             return $event;
         }
-        while (null !== $line = $this->reader->read()) {
+        if (null !== $line = $this->reader->read()) {
             // TODO: pass true here if we read as much as we could as there
             // _could_ still be more in this case.
             $this->parser->advance($line, more: false);

--- a/src/Reader/AsyncStreamReader.php
+++ b/src/Reader/AsyncStreamReader.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpTui\Term\Reader;
+
+use PhpTui\Term\Reader;
+use Revolt\EventLoop;
+use RuntimeException;
+use WeakMap;
+
+final class AsyncStreamReader implements Reader
+{
+    private string $callbackId;
+
+    /** @var WeakMap<EventLoop\Suspension<string>,true> suspensions */
+    private WeakMap $suspensions;
+    /**
+     * @param resource $stream
+     */
+    private function __construct(private $stream)
+    {
+        \assert(\class_exists(EventLoop::class), '\Revolt\EventLoop class not found');
+        $this->suspensions = new WeakMap();
+        $this->callbackId = EventLoop::onReadable($this->stream, $this->readStream(...));
+    }
+
+    public function __destruct()
+    {
+        EventLoop::cancel($this->callbackId);
+    }
+
+    public static function tty(): self
+    {
+        \stream_set_blocking(STDIN, false) || throw new RuntimeException('Failed to set stream non-blocking');
+
+        return new self(STDIN);
+    }
+
+    public function read(): ?string
+    {
+        /** @var EventLoop\Suspension<string> $suspension */
+        $suspension = EventLoop::getSuspension();
+        $this->suspensions[$suspension] = true;
+
+        return $suspension->suspend();
+    }
+
+    public function disable(): void
+    {
+        EventLoop::disable($this->callbackId);
+    }
+
+    public function enable(): void
+    {
+        EventLoop::enable($this->callbackId);
+    }
+
+    private function isStreamDead(): bool
+    {
+        return !is_resource($this->stream) || @feof($this->stream);
+    }
+
+    private function resumeSuspensions(string $data): void
+    {
+        /** @var  EventLoop\Suspension<string> $suspension */
+        foreach ($this->suspensions as $suspension => $_) {
+            $suspension->resume($data);
+        }
+    }
+
+    private function readStream(): void
+    {
+        $newData = stream_get_contents($this->stream);
+        if ($newData !== false && $newData !== '') {
+            $this->resumeSuspensions($newData);
+        } elseif ($this->isStreamDead()) {
+            EventLoop::cancel($this->callbackId);
+        }
+    }
+}


### PR DESCRIPTION
Hi 👋🙂 
This PhpTui (and term) library looks amazing 🎉 
I already have some ideas in mind, but I think it would be easier to implement them with an Asynchronous framework like [Amp](https://amphp.org/) or [React](https://reactphp.org/). Fortunately, they both support the (low level) [RevoltPhp](https://revolt.run/) event loop library, so adding support for RevoltPhp would allow to easily support both frameworks.

This PR proposes to add an `AsyncStreamReader` to read `STDIN`. If run _alone_, the `AsyncStreamReader::read` function will block until something is ready to read, **without consuming any CPU**. If run concurrently with an other task (Fiber), RevoltPhp will switch from one task to the other.

I added a minimalist example, the same that display events in terminal, but adding an other task to update the title every second. Of course, it would be better to write it with Frameworks like Amp or React, but I think it's better to stay _low level_ in this library.

Main benefits I see:
* it really eases writing of asynchronous tasks, you can have a loop for rendering, one to handle events, and another one to handle an animation. As soon as they _wait_ for something (input, time...), RevoltPhp will easily run them concurrently 
* CPU consumption is better: on my computer, `events.php` example always consume 1% of CPU, but with `async-events.php`, if I don't press any key, it's 0%! (except every second when the timer is triggered 😅 )

This PR is mainly here to start the discussion, to know if you are interested by this kind of features, if you had other plans in mind. `term` is flexible enough, if you prefer to not merge this I could easily maintain an other library providing just necessary provider.

⚠️ I had to modify the `SyncTtyEventProvider`, it runs a loop expecting the stream reader to return `null`, but with the `AsyncStreamReader` may block (asynchronously), never returning `null`, and it will create an infinite loop. Again, this is a proof of concept, could be done in a dedicated EventProvider. In the same way, the `AggregateEventProvider` and `SignalEventProvider` could modified this way.


I'm looking forward to your opinion on this, and thanks again for sharing this amazing piece of work fro the Php ecosystem 🙇 