### PR TITLE
sort constructor parameters

### DIFF
--- a/src/Terminal.php
+++ b/src/Terminal.php
@@ -36,8 +36,8 @@ final class Terminal
     public static function new(
         Painter $painter = null,
         InformationProvider  $infoProvider = null,
-        EventProvider $eventProvider = null,
         RawMode $rawMode = null,
+        EventProvider $eventProvider = null,
     ): self {
         return new self(
             $painter ?? AnsiPainter::new(StreamWriter::stdout()),


### PR DESCRIPTION
I was trying to use the lib. However, it's confusing why the `new` method has a different params sort of the class constructor.