### PR TITLE
fix: replace implicit nullable values with explicit

### DIFF
--- a/src/Terminal.php
+++ b/src/Terminal.php
@@ -34,10 +34,10 @@ final class Terminal
      * terminal will be created.
      */
     public static function new(
-        Painter $painter = null,
-        InformationProvider  $infoProvider = null,
-        RawMode $rawMode = null,
-        EventProvider $eventProvider = null,
+        ?Painter $painter = null,
+        ?InformationProvider  $infoProvider = null,
+        ?RawMode $rawMode = null,
+        ?EventProvider $eventProvider = null,
     ): self {
         return new self(
             $painter ?? AnsiPainter::new(StreamWriter::stdout()),


### PR DESCRIPTION
This change fixes the deprecation warning in php 8.4: https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated